### PR TITLE
Gdh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([custom-hot-corners], [0.5], [janrunx@gmail.com])
+AC_INIT([custom-hot-corners], [0.6], [janrunx@gmail.com])
 AM_INIT_AUTOMAKE([foreign])
 
 AC_SUBST([uuid], [$PACKAGE_NAME@janrunx.gmail.com])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([custom-hot-corners], [0.7], [janrunx@gmail.com])
+AC_INIT([custom-hot-corners], [0.8], [janrunx@gmail.com])
 AM_INIT_AUTOMAKE([foreign])
 
 AC_SUBST([uuid], [$PACKAGE_NAME@janrunx.gmail.com])

--- a/corner-widget.ui
+++ b/corner-widget.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="custom-hot-corners">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="barrierAdjustment">
@@ -54,35 +54,11 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">Barrier size</property>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="barrierSize">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="adjustment">barrierAdjustment</property>
-            <property name="numeric">True</property>
-          </object>
-          <packing>
-            <property name="left_attach">1</property>
-            <property name="top_attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
             <property name="label" translatable="yes">Pressure Threshold</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
-            <property name="top_attach">2</property>
+            <property name="top_attach">3</property>
           </packing>
         </child>
         <child>
@@ -95,7 +71,54 @@
           </object>
           <packing>
             <property name="left_attach">1</property>
+            <property name="top_attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="barrierSize">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="adjustment">barrierAdjustment</property>
+            <property name="numeric">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
             <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">Barrier size</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">Click to activate</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="clickSwitch">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">end</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">1</property>
           </packing>
         </child>
       </object>

--- a/extension.js
+++ b/extension.js
@@ -18,7 +18,7 @@ const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
-const Lang = imports.lang;
+const GObject = imports.gi.GObject;
 
 const Main = imports.ui.main;
 const Layout = imports.ui.layout;
@@ -70,10 +70,11 @@ function _updateHotCorners() {
     }
 }
 
-const CustomHotCorner = class CustomHotCorner extends Layout.HotCorner {
-    constructor(corner) {
+const CustomHotCorner = GObject.registerClass(
+class CustomHotCorner extends Layout.HotCorner {
+    _init(corner) {
         let monitor = Main.layoutManager.monitors[corner.monitorIndex];
-        super(Main.layoutManager, monitor, corner.x, corner.y);
+        super._init(Main.layoutManager, monitor, corner.x, corner.y);
         this._corner = corner;
         this._monitor = monitor;
 
@@ -230,4 +231,4 @@ const CustomHotCorner = class CustomHotCorner extends Layout.HotCorner {
         this._rippleAnimation();
         Util.spawnCommandLine(this._corner.command);
     }
-}
+});

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -1,6 +1,6 @@
 {
     "description": "Customizable hot corners.",
-    "shell-version": ["3.34"],
+    "shell-version": ["3.36"],
     "name": "Custom Hot Corners",
     "uuid": "@uuid@",
     "settings-schema": "org.gnome.shell.extensions.@PACKAGE_NAME@",

--- a/prefs.js
+++ b/prefs.js
@@ -58,6 +58,7 @@ function buildPrefsWidget() {
             let commandEntry = cwUI.get_object('commandEntry');
             let commandEntryRevealer = cwUI.get_object('commandEntryRevealer');
             let fullscreenSwitch = cwUI.get_object('fullscreenSwitch');
+            let clickSwitch = cwUI.get_object('clickSwitch');
             let barrierSizeSpinButton = cwUI.get_object('barrierSize');
             let pressureThresholdSpinButton = cwUI.get_object('pressureThreshold');
 
@@ -65,6 +66,7 @@ function buildPrefsWidget() {
             commandEntry.text = corner.command;
             commandEntryRevealer.reveal_child = corner.action === 'runCommand';
             fullscreenSwitch.active = corner.fullscreen;
+            clickSwitch.active = corner.click;
             barrierSizeSpinButton.value = corner.barrierSize;
             pressureThresholdSpinButton.value = corner.pressureThreshold;
 
@@ -78,6 +80,9 @@ function buildPrefsWidget() {
             });
             fullscreenSwitch.connect('notify::active', () => {
                 corner.fullscreen = fullscreenSwitch.active;
+            });
+            clickSwitch.connect('notify::active', () => {
+                corner.click = clickSwitch.active;
             });
             barrierSizeSpinButton.timout_id = null;
             barrierSizeSpinButton.connect('changed', () => {

--- a/schemas/org.gnome.shell.extensions.custom-hot-corners.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.custom-hot-corners.gschema.xml
@@ -11,6 +11,9 @@
     <key name='fullscreen' type='b'>
       <default>false</default>
     </key>
+    <key name='click' type='b'>
+      <default>false</default>
+    </key>
     <key name='barrier-size' type='i'>
       <default>20</default>
     </key>

--- a/settings.js
+++ b/settings.js
@@ -77,6 +77,14 @@ var Corner = class Corner {
         this._gsettings.set_boolean('fullscreen', bool_val);
     }
 
+    get click() {
+        return this._gsettings.get_boolean('click');
+    }
+
+    set click(bool_val) {
+        this._gsettings.set_boolean('click', bool_val);
+    }
+
     get barrierSize() {
         return this._gsettings.get_int('barrier-size');
     }


### PR DESCRIPTION
Hi, I added a *click to activate* option as an alternative to the hot corner. Any mouse button. Tested on Ubuntu 20.04, it's flawless with Wayland. Under the X11 session, there is a little bug which I'm unable to work around for now (tested on multiple HW configurations, not other distros so far) - when an *active window is under the corner Clutter.Actor, mouse button events are not catched.